### PR TITLE
Always choose latest version as update target

### DIFF
--- a/wombat_update.sh
+++ b/wombat_update.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 #######################################################################################################
-#																								   																		                #
-#		Author: Tim Corbly, Erin Harrington																																#
-#		Date: 2025-01-24																																							    #
-#		Description: Dummy Wombat update file for versions <= 30.3.0                                      #
-#																																																			#
+#                                                                                                     #
+#    Author: Tim Corbly, Erin Harrington, Thomas Wells                                                #
+#    Date: 2025-02-04                                                                                 #
+#    Description: Dummy Wombat update file for versions <= 30.3.0                                     #
+#                                                                                                     #
 #######################################################################################################
 
 HOME=/home/kipr

--- a/wombat_update.sh
+++ b/wombat_update.sh
@@ -3,9 +3,9 @@
 #######################################################################################################
 #																								   																		                #
 #		Author: Tim Corbly, Erin Harrington																																#
-#		Date: 2025-01-24																																							    #								
+#		Date: 2025-01-24																																							    #
 #		Description: Dummy Wombat update file for versions <= 30.3.0                                      #
-#																																																			#							
+#																																																			#
 #######################################################################################################
 
 HOME=/home/kipr
@@ -47,17 +47,11 @@ awk -F'wombat-os-' '
     split($2, ver, "."); 
     if (ver[1] >= 31 && ver[2] >= 0 && ver[3] >= 0) 
         print $0
-}')
+}' | sort | tail -n1)
 
 # Check if wombat-os-31.0.0 or greater directory exists
 if [ -z "$WOMBAT_OS_NEW" ]; then
   echo "No wombat-os-31.0.0 or higher directory found. If you downloaded wombat-os v31.0.0 or higher, please make sure that the file has been extracted to your flash drive and that there is not a duplicate folder inside the extracted folder."
-  exit 1
-fi
-
-# Check if only one directory was found
-if [ $(echo "$WOMBAT_OS_NEW" | wc -l) -ne 1 ]; then
-  echo "Multiple matches found for wombat-os-31Update. Please specify the correct path."
   exit 1
 fi
 


### PR DESCRIPTION
There is a small issue in the current version.
If you had multiple update versions on the same USB, it would detect both of them and fail.

The new version takes the options, sorts them, and chooses the final option, which should always correspond to the latest version available.

I also switched the tabs in the header for spaces to provide better viewing consistency across editors and with the rest of the file.